### PR TITLE
feat: add card component

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,5 +1,48 @@
-const Card = () => (
-  <div className="w-full h-52 bg-gray-700 text-white rounded-xl" />
+import { Card, CardBody, CardFooter, Image } from '@nextui-org/react';
+import { GrView } from 'react-icons/gr';
+import { FaThumbsUp } from 'react-icons/fa6';
+
+type Props = {
+  img: string;
+  title: string;
+  writer: string;
+  viewCount: string;
+  likeCount: string;
+};
+
+const CustomCard = ({ img, title, writer, viewCount, likeCount }: Props) => (
+  <Card
+    shadow="sm"
+    isPressable
+    onPress={() => console.log('Go to detail page')}
+  >
+    <CardBody className="overflow-visible p-0">
+      <Image
+        shadow="sm"
+        radius="lg"
+        width="100%"
+        alt={title}
+        className="w-full object-cover"
+        src={img}
+      />
+    </CardBody>
+    <CardFooter className="flex-col items-start w-full gap-1 px-1">
+      <p className="text-sm truncate w-full text-left">{title}</p>
+      <p className="text-xs truncate w-full text-left text-gray-400">
+        {writer}
+      </p>
+      <div className="flex items-center justify-between w-full">
+        <div className="flex items-center gap-1">
+          <GrView className="text-gray-400" />
+          <p className="text-xs text-gray-400">{viewCount}</p>
+        </div>
+        <div className="flex items-center gap-1">
+          <FaThumbsUp className="text-gray-400" />
+          <p className="text-xs text-gray-400">{likeCount}</p>
+        </div>
+      </div>
+    </CardFooter>
+  </Card>
 );
 
-export default Card;
+export default CustomCard;

--- a/src/data/card.ts
+++ b/src/data/card.ts
@@ -1,0 +1,90 @@
+import { formatCompactNumber } from 'lib/utils';
+
+const cards = [
+  {
+    img: 'https://story-a.tapas.io/prod/story/e65d3196-6654-4fbb-b9c2-101b7fe9d3f4/c2/2x/c2_I_Don_t_Want_To_Play_Matchmaker__s2.png',
+    title: 'Beyond the Horizon',
+    writer: 'Emma Williams',
+    viewCount: formatCompactNumber.format(8901000),
+    likeCount: formatCompactNumber.format(541280),
+  },
+  {
+    img: 'https://story-a.tapas.io/prod/story/c3385a06-eed0-40b1-bf9c-2f5bf29e9d91/c2/2x/c2_Devoted_to_Diamond_s.png',
+    title: 'Forgotten Legends',
+    writer: 'John Smith',
+    viewCount: formatCompactNumber.format(67503),
+    likeCount: formatCompactNumber.format(7593),
+  },
+  {
+    img: 'https://story-a.tapas.io/prod/story/0a56ec41-296e-495f-8e20-af51e4c8b5c5/c2/2x/c2_Revenge_on_the_Real_One_s2.png',
+    title: 'Whispers of Destiny',
+    writer: 'Sophia Johnson',
+    viewCount: formatCompactNumber.format(90912),
+    likeCount: formatCompactNumber.format(48007),
+  },
+  {
+    img: 'https://story-a.tapas.io/prod/story/c2/2x/c2_Villains_are_Destined_to_Die_S4.png',
+    title: 'Shadows of the Past',
+    writer: 'Noah Davis',
+    viewCount: formatCompactNumber.format(57419),
+    likeCount: formatCompactNumber.format(65943),
+  },
+  {
+    img: 'https://story-a.tapas.io/prod/story/30f7eb12-f16d-45c9-aec2-fb0ab8aae749/c2/2x/c2_The_Dying_Villainess_Denies_Adoption.png',
+    title: 'Echoes of Time',
+    writer: 'Isabella Miller',
+    viewCount: formatCompactNumber.format(10792),
+    likeCount: formatCompactNumber.format(32482),
+  },
+  {
+    img: 'https://story-a.tapas.io/prod/story/c2/2x/c2_Marriage_of_Convenience______.png',
+    title: 'The Last Warrior',
+    writer: 'Mason Wilson',
+    viewCount: formatCompactNumber.format(48902),
+    likeCount: formatCompactNumber.format(87234),
+  },
+  {
+    img: 'https://story-a.tapas.io/prod/story/e9c86ace-5855-4372-9a5c-1738b0f889f6/c2/2x/c2_A_Ranker_s_Guide_to_the_Good_Life.png',
+    title: 'Journey to the Unknown',
+    writer: 'Liam Brown',
+    viewCount: formatCompactNumber.format(73914),
+    likeCount: formatCompactNumber.format(19203),
+  },
+  {
+    img: 'https://story-a.tapas.io/prod/story/c2/2x/c2_Regas.png',
+    title: 'The Final Stand',
+    writer: 'Olivia Taylor',
+    viewCount: formatCompactNumber.format(54182),
+    likeCount: formatCompactNumber.format(90123),
+  },
+  {
+    img: 'https://story-a.tapas.io/prod/story/75be7978-2ebf-48e1-adbc-c9389da7de31/c2/2x/c2_Second_Try_Idol_s4.png',
+    title: 'Into the Night',
+    writer: 'Lucas Moore',
+    viewCount: formatCompactNumber.format(784),
+    likeCount: formatCompactNumber.format(523),
+  },
+  {
+    img: 'https://story-a.tapas.io/prod/story/e3e8b4df-ee11-47d9-a109-e1b4109c716c/c2/2x/c2_Mother_s_Contract_Marriage_s2.png',
+    title: 'Eternal Promise',
+    writer: 'Edward Frank',
+    viewCount: formatCompactNumber.format(35249),
+    likeCount: formatCompactNumber.format(37498),
+  },
+  {
+    img: 'https://story-a.tapas.io/prod/story/9fa94aa1-fc1d-4629-9a1b-2cfaa9192cdc/c2/2x/c2_I_Fell_into_a_Reverse_Harem_Game__s3.png',
+    title: 'Eternal Promise',
+    writer: 'Iruka',
+    viewCount: formatCompactNumber.format(73390),
+    likeCount: formatCompactNumber.format(4935),
+  },
+  {
+    img: 'https://story-a.tapas.io/prod/story/ca428951-af2c-452e-b87d-64597bfab05d/c2/2x/c2_What_It_Takes_to_Be_a_Villainess_s2.png',
+    title: 'A New Dawn',
+    writer: 'Brian Lee',
+    viewCount: formatCompactNumber.format(69252),
+    likeCount: formatCompactNumber.format(9209),
+  },
+];
+
+export default cards;

--- a/src/data/selectedBox.ts
+++ b/src/data/selectedBox.ts
@@ -1,0 +1,33 @@
+type SelectedItem = {
+  key: string;
+  text: string;
+};
+
+const selectedList: SelectedItem[] = [
+  {
+    key: 'all',
+    text: 'All',
+  },
+  {
+    key: 'today',
+    text: 'Today',
+  },
+  {
+    key: 'last7',
+    text: 'Last 7 Days',
+  },
+  {
+    key: 'last14',
+    text: 'Last 14 Days',
+  },
+  {
+    key: 'last30',
+    text: 'Last 30 Days',
+  },
+  {
+    key: 'last90',
+    text: 'Last 90 Days',
+  },
+];
+
+export default selectedList;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,4 +3,9 @@ import { twMerge } from 'tailwind-merge';
 
 export const cn = (...args: ClassValue[]) => twMerge(clsx(args));
 
+export const formatCompactNumber = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  compactDisplay: 'short',
+});
+
 export default null;

--- a/src/routes/recently.tsx
+++ b/src/routes/recently.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState, useMemo } from 'react';
 import {
   Dropdown,
   DropdownTrigger,
@@ -12,44 +12,15 @@ import Card from 'components/Card';
 import LayoutContainer from 'components/layout/LayoutContainer';
 import PageTitle from 'components/PageTitle';
 
-type SelectedItem = {
-  key: string;
-  text: string;
-};
-
-const selectedList: SelectedItem[] = [
-  {
-    key: 'all',
-    text: 'All',
-  },
-  {
-    key: 'today',
-    text: 'Today',
-  },
-  {
-    key: 'last7',
-    text: 'Last 7 Days',
-  },
-  {
-    key: 'last14',
-    text: 'Last 14 Days',
-  },
-  {
-    key: 'last30',
-    text: 'Last 30 Days',
-  },
-  {
-    key: 'last90',
-    text: 'Last 90 Days',
-  },
-];
+import cards from 'data/card';
+import selectedList from 'data/selectedBox';
 
 const Recently = () => {
-  const [selectedKeys, setSelectedKeys] = React.useState(
+  const [selectedKeys, setSelectedKeys] = useState(
     new Set([selectedList[0].key]),
   );
 
-  const selectedText = React.useMemo(
+  const selectedText = useMemo(
     () =>
       selectedList.find(
         (item) =>
@@ -65,7 +36,7 @@ const Recently = () => {
 
   return (
     <LayoutContainer>
-      <div className="sticky top-0 py-4 bg-white dark:bg-neutral-900">
+      <div className="sticky top-0 z-10 py-4 bg-white dark:bg-neutral-900">
         <PageTitle
           endContent={
             <Dropdown>
@@ -94,9 +65,9 @@ const Recently = () => {
           Recently Viewed Posts
         </PageTitle>
       </div>
-      <div className="grid grid-cols-2 gap-4 pb-4">
-        {new Array(20).fill(0).map((idx) => (
-          <Card key={`card-${idx}`} />
+      <div className="relative z-0 grid grid-cols-3 gap-2 pb-4">
+        {cards.map((card) => (
+          <Card key={`card-${card.title}`} {...card} />
         ))}
       </div>
     </LayoutContainer>

--- a/src/routes/recommended.tsx
+++ b/src/routes/recommended.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState, useMemo } from 'react';
 import {
   Dropdown,
   DropdownTrigger,
@@ -12,44 +12,15 @@ import Card from 'components/Card';
 import LayoutContainer from 'components/layout/LayoutContainer';
 import PageTitle from 'components/PageTitle';
 
-type SelectedItem = {
-  key: string;
-  text: string;
-};
-
-const selectedList: SelectedItem[] = [
-  {
-    key: 'all',
-    text: 'All',
-  },
-  {
-    key: 'today',
-    text: 'Today',
-  },
-  {
-    key: 'last7',
-    text: 'Last 7 Days',
-  },
-  {
-    key: 'last14',
-    text: 'Last 14 Days',
-  },
-  {
-    key: 'last30',
-    text: 'Last 30 Days',
-  },
-  {
-    key: 'last90',
-    text: 'Last 90 Days',
-  },
-];
+import cards from 'data/card';
+import selectedList from 'data/selectedBox';
 
 const Recommended = () => {
-  const [selectedKeys, setSelectedKeys] = React.useState(
+  const [selectedKeys, setSelectedKeys] = useState(
     new Set([selectedList[0].key]),
   );
 
-  const selectedText = React.useMemo(
+  const selectedText = useMemo(
     () =>
       selectedList.find(
         (item) =>
@@ -94,9 +65,9 @@ const Recommended = () => {
           Recommended Posts
         </PageTitle>
       </div>
-      <div className="grid grid-cols-2 gap-4 pb-4">
-        {new Array(20).fill(0).map((idx) => (
-          <Card key={`card-${idx}`} />
+      <div className="grid grid-cols-3 gap-4 pb-4">
+        {cards.map((card) => (
+          <Card key={`card-${card.title}`} {...card} />
         ))}
       </div>
     </LayoutContainer>


### PR DESCRIPTION
## Type of Work

- [ ] Bugfix
- [x] Feature
- [ ] Release
- [ ] Refactor
- [ ] Style
- [ ] Environment
- [ ] Other, please describe:

## Summary of Work
- Added a Card component

## Description of Work
- Implemented `components/Card.tsx` which receives `img, title, writer, viewCount, likeCount` as props. These values may change later after API integration.
- Added `formatCompactNumber` to `lib/utils.ts`, which converts numbers into a compact format (e.g., 541280 -> 541K).
- Introduced `data/card` and `data/selectedBox` for shared use of temporary data.

![image](https://github.com/user-attachments/assets/2c7e0f32-6ad9-4fe8-9d77-05f9000230d7)

## Testing Requirements
- Click the `profile` tab and then the `Recently Viewed Posts` button. 
  - Alternatively, navigate directly to `/profile/recently`.
- Verify that the new card components are displayed in a grid format, as shown in the attached screenshot.
