### PR TITLE
feat: add main screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-icons": "^5.3.0",
     "react-router-dom": "^6.27.0",
     "react-use": "^17.5.1",
+    "swiper": "^11.1.14",
     "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-use:
         specifier: ^17.5.1
         version: 17.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      swiper:
+        specifier: ^11.1.14
+        version: 11.1.14
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.5.4
@@ -3642,6 +3645,10 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  swiper@11.1.14:
+    resolution: {integrity: sha512-VbQLQXC04io6AoAjIUWuZwW4MSYozkcP9KjLdrsG/00Q/yiwvhz9RQyt0nHXV10hi9NVnDNy1/wv7Dzq1lkOCQ==}
+    engines: {node: '>= 4.7.0'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -8628,6 +8635,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swiper@11.1.14: {}
 
   symbol-tree@3.2.4: {}
 

--- a/src/components/layout/LayoutContainer.tsx
+++ b/src/components/layout/LayoutContainer.tsx
@@ -4,12 +4,13 @@ import BottomNavigation from 'components/layout/BottomNavigation';
 
 type Props = {
   children: ReactNode;
+  isSpacing?: boolean;
 };
 
-const LayoutContainer = ({ children }: Props) => (
+const LayoutContainer = ({ children, isSpacing }: Props) => (
   <div className="relative flex justify-evenly w-full mx-auto lg:max-w-[1024px] xl:max-w-[1280px] xxl:max-w[1440px]">
     <div className="flex flex-col w-full max-w-[500px]">
-      <MainContainer>{children}</MainContainer>
+      <MainContainer isSpacing={isSpacing}>{children}</MainContainer>
       <BottomNavigation />
     </div>
   </div>

--- a/src/components/layout/MainContainer.tsx
+++ b/src/components/layout/MainContainer.tsx
@@ -3,9 +3,10 @@ import { cn } from 'lib/utils';
 
 type Props = {
   children: ReactNode;
+  isSpacing?: boolean;
 };
 
-const MainContainer = ({ children }: Props) => (
+const MainContainer = ({ children, isSpacing = true }: Props) => (
   <>
     <div
       className={cn(
@@ -16,9 +17,10 @@ const MainContainer = ({ children }: Props) => (
     <div className="relative flex flex-col w-full max-w-[500px] h-screen max-h-screen mx-auto lg:mx-0">
       <div
         className={cn(
-          'overflow-y-auto max-h-[calc(100vh-4rem)] px-4',
+          'overflow-y-auto max-h-[calc(100vh-4rem)]',
           'bg-white dark:bg-neutral-900',
           'text-neutral-950 dark:text-neutral-100',
+          isSpacing && 'px-4',
         )}
       >
         {children}

--- a/src/routes/profile.tsx
+++ b/src/routes/profile.tsx
@@ -1,11 +1,14 @@
+import { useState } from 'react';
 import { Listbox, ListboxItem } from '@nextui-org/react';
 import { FaChevronRight } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import { format } from 'date-fns/format';
+import WebApp from '@twa-dev/sdk';
 
 import useTelegramAuth from 'hooks/useTelegramAuth';
 
 import LayoutContainer from 'components/layout/LayoutContainer';
+import ThemeControlSwitch from 'components/ThemeControlSwitch';
 
 type Key = string | number;
 
@@ -29,6 +32,7 @@ const list: ListItem[] = [
 ];
 
 const Profile = () => {
+  const [count, setCount] = useState(0);
   const { isTelegramView, telegramAuthData } = useTelegramAuth();
 
   const navigate = useNavigate();
@@ -43,6 +47,21 @@ const Profile = () => {
   return (
     <LayoutContainer>
       <div className="py-4">
+        <div className="card">
+          <button onClick={() => setCount((prevState) => prevState + 1)}>
+            count is {count}
+          </button>
+        </div>
+        <div className="card">
+          <button
+            onClick={() =>
+              WebApp.showAlert(`Hello World! Current count is ${count}`)
+            }
+          >
+            Show Alert
+          </button>
+        </div>
+        <ThemeControlSwitch />
         {isTelegramView && telegramAuthData.user && (
           <div className="flex flex-col gap-1 px-3 mb-4 text-xs overflow-hidden break-all">
             <div className="grid grid-cols-2">

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -1,32 +1,85 @@
-import { useState } from 'react';
-import WebApp from '@twa-dev/sdk';
+import { Image, Tabs, Tab } from '@nextui-org/react';
+import { MdUpdate, MdTrendingUp } from 'react-icons/md';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Autoplay, Pagination, Navigation } from 'swiper/modules';
 
+import Card from 'components/Card';
 import LayoutContainer from 'components/layout/LayoutContainer';
-import ThemeControlSwitch from 'components/ThemeControlSwitch';
 
-const Root = () => {
-  const [count, setCount] = useState(0);
-  return (
-    <LayoutContainer>
-      <h1>WebTON</h1>
-      <div className="card">
-        <button onClick={() => setCount((prevState) => prevState + 1)}>
-          count is {count}
-        </button>
-      </div>
+import cards from 'data/card';
 
-      <div className="card">
-        <button
-          onClick={() =>
-            WebApp.showAlert(`Hello World! Current count is ${count}`)
-          }
+import 'swiper/css';
+import 'swiper/css/pagination';
+
+const banners = [
+  'https://pbs.twimg.com/media/D_Zo3S8UEAUxia-.jpg',
+  'https://cdn.myportfolio.com/cf6ca8da-f458-4ed3-832e-4247757e6e7f/29ab3827-40a0-42d3-83cf-43ea25d50fbf_rw_1200.jpg?h=9684a4c09a4806a5be8ad2ee45b457a0',
+  'https://static1.srcdn.com/wordpress/wp-content/uploads/2024/07/kill-the-hero-revenge-manhwa-banner.jpg',
+];
+
+const Root = () => (
+  <LayoutContainer isSpacing={false}>
+    <div className="flex flex-col gap-4 pb-4">
+      <div className="w-full h-[200px]">
+        <Swiper
+          spaceBetween={0}
+          slidesPerView={1}
+          autoplay={{
+            delay: 3000,
+            disableOnInteraction: false,
+          }}
+          pagination
+          navigation
+          modules={[Autoplay, Pagination, Navigation]}
+          className="h-full"
         >
-          Show Alert
-        </button>
+          {banners.map((src) => (
+            <SwiperSlide>
+              <Image
+                shadow="sm"
+                radius="lg"
+                width="100%"
+                alt="banner"
+                className="w-full object-cover rounded-none"
+                src={src}
+              />
+            </SwiperSlide>
+          ))}
+        </Swiper>
       </div>
-      <ThemeControlSwitch />
-    </LayoutContainer>
-  );
-};
+
+      <div className="flex flex-col gap-1 px-4">
+        <div className="flex w-full flex-col ">
+          <Tabs aria-label="Options" variant="solid">
+            <Tab
+              key="latest"
+              title={
+                <div className="flex items-center space-x-2">
+                  <MdUpdate />
+                  <span>Latest</span>
+                </div>
+              }
+            />
+            <Tab
+              key="popular"
+              title={
+                <div className="flex items-center space-x-2">
+                  <MdTrendingUp />
+                  <span>Popular</span>
+                </div>
+              }
+            />
+          </Tabs>
+        </div>
+
+        <div className="relative z-0 grid grid-cols-3 gap-2">
+          {cards.map((card) => (
+            <Card key={`card-${card.title}`} {...card} />
+          ))}
+        </div>
+      </div>
+    </div>
+  </LayoutContainer>
+);
 
 export default Root;


### PR DESCRIPTION
## Type of Work

- [ ] Bugfix
- [x] Feature
- [ ] Release
- [ ] Refactor
- [ ] Style
- [ ] Environment
- [ ] Other, please describe:

## Summary of Work
- Main screen UI implementation

## Description of Work
- Implemented the main screen UI.
- Used `Swiper` to display banner images in a slide format.
- Added Tabs from NextUI.

![image](https://github.com/user-attachments/assets/2a917504-c559-4cd7-b079-fa40bd734619)

## Testing Requirements
- You can check the implementation directly on the `/` route.
- Verify that the slide effect works properly in the banner section.
- Check if the clicked tab is activated when switching between tabs.
- Ensure the card list displays correctly.
